### PR TITLE
Add Christine brand colors throughout site 

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -25,11 +25,11 @@ const navItems = [
   { href: "/contact", label: "Contact" },
 ];
 
-/** Generate nav classes using standard Tailwind classes */
+/** Generate nav classes using YOUR brand colors */
 const getNavClasses = (href: string) => {
   const baseClasses =
-    "text-zinc-600 hover:text-orange-600 focus:text-orange-600 transition-colors duration-200 hover:underline";
-  const activeClasses = "text-orange-600 font-medium";
+    "text-scorpion hover:text-christine focus:text-christine transition-colors duration-200 hover:underline";
+  const activeClasses = "text-christine font-medium";
 
   return isCurrent(href) ? `${baseClasses} ${activeClasses}` : baseClasses;
 };
@@ -59,23 +59,25 @@ const getAriaCurrent = (href: string) => (isCurrent(href) ? "page" : undefined);
     <title>{title} — Shooting Quarterly</title>
   </head>
 
-  <body class="min-h-screen flex flex-col bg-zinc-100 text-black font-sans">
+  <body
+    class="min-h-screen flex flex-col bg-black-haze text-pure-black font-sans"
+  >
     <!-- Header with Navigation -->
-    <header class="bg-white shadow-md border-b border-zinc-200">
+    <header class="bg-white shadow-md border-b border-black-haze">
       <div
         class="container mx-auto px-4 py-4 flex items-center justify-between"
       >
         <!-- Logo/Brand -->
         <a
           href="/"
-          class="text-xl font-bold text-black hover:text-orange-600 transition-colors duration-200"
+          class="text-xl font-bold text-pure-black hover:text-christine transition-colors duration-200"
         >
           Shooting Quarterly
         </a>
 
         <!-- Mobile Menu Button -->
         <button
-          class="sm:hidden text-zinc-600 hover:text-orange-600 transition-colors duration-200"
+          class="sm:hidden text-scorpion hover:text-christine transition-colors duration-200"
           id="mobile-menu-button"
           aria-label="Toggle navigation menu"
           aria-expanded="false"
@@ -117,7 +119,7 @@ const getAriaCurrent = (href: string) => (isCurrent(href) ? "page" : undefined);
       <!-- Mobile Navigation -->
       <div
         id="mobile-menu"
-        class="sm:hidden hidden bg-white border-t border-zinc-200"
+        class="sm:hidden hidden bg-white border-t border-black-haze"
         role="navigation"
         aria-label="Mobile navigation"
       >
@@ -144,7 +146,7 @@ const getAriaCurrent = (href: string) => (isCurrent(href) ? "page" : undefined);
 
     <!-- Footer -->
     <footer
-      class="bg-zinc-100 text-zinc-600 text-center text-xs py-4 border-t border-zinc-200"
+      class="bg-black-haze text-scorpion text-center text-xs py-4 border-t border-black-haze/50"
     >
       <p>
         © {new Date().getFullYear()} Shooting Quarterly - Shooting is Soothing!

--- a/src/pages/brand-test.astro
+++ b/src/pages/brand-test.astro
@@ -1,0 +1,157 @@
+---
+// src/pages/brand-test.astro
+import Layout from "../layouts/Base.astro";
+---
+
+<Layout title="Brand Colors Test">
+  <div class="max-w-4xl mx-auto">
+    <h1 class="text-3xl font-bold mb-8 text-center text-pure-black">
+      Brand Colors Test Page
+    </h1>
+
+    <!-- Color Swatches -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-12">
+      <div class="space-y-4">
+        <h2 class="text-xl font-semibold text-pure-black">
+          Current Colors (Before)
+        </h2>
+
+        <div class="flex items-center space-x-4">
+          <div class="w-16 h-16 bg-orange-600 rounded-lg shadow-md"></div>
+          <div>
+            <p class="font-medium">Old Orange</p>
+            <p class="text-sm text-gray-600">#EA580C (orange-600)</p>
+          </div>
+        </div>
+
+        <div class="flex items-center space-x-4">
+          <div class="w-16 h-16 bg-zinc-100 rounded-lg shadow-md border"></div>
+          <div>
+            <p class="font-medium">Old Background</p>
+            <p class="text-sm text-gray-600">#F4F4F5 (zinc-100)</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-xl font-semibold text-pure-black">
+          Your Brand Colors (After)
+        </h2>
+
+        <div class="flex items-center space-x-4">
+          <div class="w-16 h-16 bg-christine rounded-lg shadow-md"></div>
+          <div>
+            <p class="font-medium text-christine">Christine Orange</p>
+            <p class="text-sm text-scorpion">#E9560D (your brand)</p>
+          </div>
+        </div>
+
+        <div class="flex items-center space-x-4">
+          <div class="w-16 h-16 bg-black-haze rounded-lg shadow-md border">
+          </div>
+          <div>
+            <p class="font-medium">Black Haze Background</p>
+            <p class="text-sm text-scorpion">#EAEBEB (your brand)</p>
+          </div>
+        </div>
+
+        <div class="flex items-center space-x-4">
+          <div class="w-16 h-16 bg-scorpion rounded-lg shadow-md"></div>
+          <div>
+            <p class="font-medium text-white">Scorpion Gray</p>
+            <p class="text-sm text-scorpion">#575656 (your brand)</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Navigation Color Test -->
+    <div class="bg-white p-6 rounded-lg shadow-md mb-8">
+      <h2 class="text-xl font-semibold mb-4 text-pure-black">
+        Navigation Color Test
+      </h2>
+
+      <div class="space-y-4">
+        <div class="flex space-x-6">
+          <span class="text-orange-600 hover:underline cursor-pointer"
+            >Old Orange Link</span
+          >
+          <span class="text-christine hover:underline cursor-pointer"
+            >Your Christine Orange Link</span
+          >
+        </div>
+
+        <div class="flex space-x-6">
+          <span class="text-zinc-600">Old Gray Text</span>
+          <span class="text-scorpion">Your Scorpion Gray Text</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Button Test -->
+    <div class="bg-white p-6 rounded-lg shadow-md mb-8">
+      <h2 class="text-xl font-semibold mb-4 text-pure-black">
+        Button Color Test
+      </h2>
+
+      <div class="flex flex-wrap gap-4">
+        <button
+          class="px-4 py-2 bg-orange-600 hover:bg-orange-700 text-white rounded transition-colors"
+        >
+          Old Orange Button
+        </button>
+
+        <button
+          class="px-4 py-2 bg-christine hover:bg-christine-hover text-white rounded transition-colors"
+        >
+          Your Christine Button
+        </button>
+
+        <button
+          class="px-4 py-2 border border-orange-600 text-orange-600 hover:bg-orange-50 rounded transition-colors"
+        >
+          Old Outline Button
+        </button>
+
+        <button
+          class="px-4 py-2 border border-christine text-christine hover:bg-black-haze rounded transition-colors"
+        >
+          Your Christine Outline
+        </button>
+      </div>
+    </div>
+
+    <!-- Hero Section Preview -->
+    <div
+      class="bg-gradient-to-r from-white to-black-haze p-8 rounded-lg shadow-md"
+    >
+      <div class="text-center">
+        <h1 class="text-4xl font-bold text-pure-black mb-4">
+          Shooting is Soothing!
+        </h1>
+        <p class="text-lg text-scorpion mb-6">
+          Building a connected sport shooting community
+        </p>
+        <div class="flex justify-center space-x-4">
+          <button
+            class="px-6 py-3 bg-christine hover:bg-christine-hover text-white rounded-lg font-medium transition-colors"
+          >
+            Read Stories
+          </button>
+          <button
+            class="px-6 py-3 border border-christine text-christine hover:bg-black-haze rounded-lg font-medium transition-colors"
+          >
+            Book Session
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-8 text-center">
+      <p class="text-scorpion">
+        <strong>Can you see the difference?</strong> Your Christine orange should
+        be slightly more vibrant and warmer than the standard orange.
+      </p>
+    </div>
+  </div>
+</Layout>


### PR DESCRIPTION
- Replace generic orange-600 with brand Christine orange (#E9560D)
- Update background to Black Haze (#EAEBEB) 
- Use Scorpion gray (#575656) for secondary text
- Ensure consistent brand colors in navigation, buttons, and layout
- Add brand color test page for verification

Fixes: Brand consistency issues mentioned in foundation audit